### PR TITLE
Invalid CLI host in non-default namespaces

### DIFF
--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               protocol: TCP
           env:
             - name: TEMPORAL_CLI_ADDRESS
-              value: {{ .Release.Name }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
+              value: {{ include "temporal.fullname" . }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
           livenessProbe:
               exec:
                 command:


### PR DESCRIPTION
This fixes admintools where it was given an invalid hostname for
connecting to temporal frontend.